### PR TITLE
Simplify work loop and fix params

### DIFF
--- a/Gig Economy - Artificial Society/deliveries_model.py
+++ b/Gig Economy - Artificial Society/deliveries_model.py
@@ -13,15 +13,15 @@ class DeliveryAgent(Agent):
         self.state = "satisfeito"
 
     def step(self):
-        # Simula trabalho em um dia
+        # Each step represents one day of work
         total_hours = 0
         earnings = 0
         while total_hours < self.model.daily_work_limit and earnings < self.model.daily_income_target:
-            delivery_time = self.random.randint(*self.model.delivery_time_range)
-            delivery_value = self.random.randint(*self.model.delivery_value_range)
-            total_hours += delivery_time / 60
-            earnings += delivery_value
-            if total_hours >= 12:
+            minutes = self.random.randint(*self.model.delivery_time_range)
+            value = self.random.uniform(*self.model.delivery_value_range)
+            total_hours += minutes / 60
+            earnings += value
+            if total_hours >= 12:  # don't work more than 12h straight
                 break
 
         self.hours_worked = total_hours

--- a/Gig Economy - Artificial Society/server.py
+++ b/Gig Economy - Artificial Society/server.py
@@ -23,9 +23,9 @@ chart = ChartModule([
 model_params = {
     "N": 50,
     "daily_income_target": 100,
-    "daily_work_limit": 12,
-    "delivery_value_range": (7.5, 10),
-    "delivery_time_range": (30, 60)
+    "daily_work_limit": 8,
+    "delivery_value_range": (8, 15),
+    "delivery_time_range": (30, 60),
 }
 
 server = ModularServer(
@@ -36,5 +36,5 @@ server = ModularServer(
 )
 
 server.port = 8521
-server.running = False  # Encerra se estiver rodando
+server.running = False  # stop previous server if running
 server.launch()


### PR DESCRIPTION
## Summary
- simplify daily work logic so each step represents a day
- use `uniform` for delivery value and limit continuous work to 12h
- correct server parameters to use integer value range and 8h target

## Testing
- `python -m py_compile 'Gig Economy - Artificial Society/deliveries_model.py' 'Gig Economy - Artificial Society/server.py'`

------
https://chatgpt.com/codex/tasks/task_e_684c330cc994832e82830cd7b5c3dbed