### PR TITLE
Add hours worked data and scatter chart

### DIFF
--- a/Gig Economy - Artificial Society/deliveries_model.py
+++ b/Gig Economy - Artificial Society/deliveries_model.py
@@ -74,7 +74,8 @@ class DeliveryModel(Model):
             model_reporters={
                 "Satisfeitos": lambda m: sum([1 for a in m.schedule.agents if a.state == "satisfeito"]),
                 "NaoSatisfeitos": lambda m: sum([1 for a in m.schedule.agents if a.state == "não satisfeito"]),
-                "Exaustos": lambda m: sum([1 for a in m.schedule.agents if a.state == "exausto"])
+                "Exaustos": lambda m: sum([1 for a in m.schedule.agents if a.state == "exausto"]),
+                "HorasTrabalhadas": lambda m: sum([a.hours_worked for a in m.schedule.agents])
             }
         )
 

--- a/Gig Economy - Artificial Society/server.py
+++ b/Gig Economy - Artificial Society/server.py
@@ -17,11 +17,27 @@ def agent_portrayal(agent):
 
 grid = CanvasGrid(agent_portrayal, 50, 50, 500, 500)
 
-chart = ChartModule([
-    {"Label": "Satisfeitos", "Color": "green"},
-    {"Label": "NaoSatisfeitos", "Color": "orange"},
-    {"Label": "Exaustos", "Color": "red"}
-])
+chart = ChartModule(
+    [
+        {"Label": "Satisfeitos", "Color": "green"},
+        {"Label": "NaoSatisfeitos", "Color": "orange"},
+        {"Label": "Exaustos", "Color": "red"},
+    ],
+    chart_type="line",
+    title="Estados dos Entregadores",
+    x_label="Ticks",
+    y_label="Agentes",
+)
+
+hours_chart = ChartModule(
+    [
+        {"Label": "HorasTrabalhadas", "Color": "blue"},
+    ],
+    chart_type="scatter",
+    title="Horas Trabalhadas por Tick",
+    x_label="Ticks",
+    y_label="Horas",
+)
 
 model_params = {
     "N": 1000,
@@ -33,7 +49,7 @@ model_params = {
 
 server = ModularServer(
     DeliveryModel,
-    [grid, chart],
+    [grid, chart, hours_chart],
     "Modelo de Entregadores",
     model_params
 )


### PR DESCRIPTION
## Summary
- collect total worked hours from agents
- display hours worked in a new scatter chart
- give both charts titles and axis labels

## Testing
- `python -m py_compile 'Gig Economy - Artificial Society/deliveries_model.py' 'Gig Economy - Artificial Society/server.py'`

------
https://chatgpt.com/codex/tasks/task_e_684c3917195c832eb1a7385a1725e557