### PR TITLE
Add delivery agent schedule variety

### DIFF
--- a/Gig Economy - Artificial Society/deliveries_model.py
+++ b/Gig Economy - Artificial Society/deliveries_model.py
@@ -13,25 +13,52 @@ class DeliveryAgent(Agent):
         self.days_overworked = 0
         self.state = "satisfeito"
 
+        # Define se o entregador trabalha meio período ou período integral
+        if self.random.random() < 0.5:
+            self.work_type = "part_time"
+            self.daily_work_limit = self.random.uniform(
+                *self.model.part_time_work_range
+            )
+            self.daily_income_target = self.random.uniform(
+                *self.model.part_time_income_range
+            )
+        else:
+            self.work_type = "full_time"
+            self.daily_work_limit = self.random.uniform(
+                *self.model.full_time_work_range
+            )
+            self.daily_income_target = self.random.uniform(
+                *self.model.full_time_income_range
+            )
+
     def step(self):
-        # Simula trabalho em um dia
+        """Simula um dia de trabalho do entregador."""
         total_hours = 0
         earnings = 0
         deliveries = 0
-        while total_hours < self.model.daily_work_limit and earnings < self.model.daily_income_target:
-            delivery_time = self.random.randint(*self.model.delivery_time_range)
-            delivery_value = self.random.uniform(*self.model.delivery_value_range)
-            total_hours += delivery_time / 60
-            earnings += delivery_value
-            deliveries += 1
-            if total_hours >= 12:
+
+        # Continua trabalhando enquanto houver horas disponíveis e não atingir a meta
+        while total_hours < self.daily_work_limit and earnings < self.daily_income_target:
+            # Tempo de espera até a próxima entrega
+            wait_time = self.random.uniform(*self.model.wait_time_range)
+            total_hours += wait_time / 60
+            if total_hours >= self.daily_work_limit:
                 break
+
+            # Decide se aceita a entrega
+            if self.random.random() < self.model.acceptance_rate:
+                delivery_time = self.random.randint(*self.model.delivery_time_range)
+                delivery_value = self.random.uniform(*self.model.delivery_value_range)
+                total_hours += delivery_time / 60
+                earnings += delivery_value
+                deliveries += 1
+            # Se não aceitar, volta para o loop e espera a próxima
 
         self.hours_worked = total_hours
         self.earnings = earnings
         self.deliveries = deliveries
 
-        if earnings >= self.model.daily_income_target and total_hours <= 10:
+        if earnings >= self.daily_income_target and total_hours <= 10:
             self.state = "satisfeito"
             self.days_overworked = 0
         elif total_hours > 10:
@@ -52,7 +79,20 @@ class DeliveryAgent(Agent):
 
 
 class DeliveryModel(Model):
-    def __init__(self, N=50, daily_income_target=80, daily_work_limit=12, delivery_value_range=(8, 15), delivery_time_range=(30, 60)):
+    def __init__(
+        self,
+        N=50,
+        daily_income_target=80,
+        daily_work_limit=12,
+        delivery_value_range=(8, 15),
+        delivery_time_range=(30, 60),
+        part_time_work_range=(2, 4),
+        full_time_work_range=(6, 12),
+        part_time_income_range=(20, 50),
+        full_time_income_range=(50, 100),
+        wait_time_range=(15, 30),
+        acceptance_rate=0.8,
+    ):
         super().__init__()
         self.num_agents = N
         self.grid = MultiGrid(50, 50, True)
@@ -62,6 +102,12 @@ class DeliveryModel(Model):
         self.daily_work_limit = daily_work_limit
         self.delivery_value_range = delivery_value_range
         self.delivery_time_range = delivery_time_range
+        self.part_time_work_range = part_time_work_range
+        self.full_time_work_range = full_time_work_range
+        self.part_time_income_range = part_time_income_range
+        self.full_time_income_range = full_time_income_range
+        self.wait_time_range = wait_time_range
+        self.acceptance_rate = acceptance_rate
 
         for i in range(self.num_agents):
             a = DeliveryAgent(i, self)

--- a/Gig Economy - Artificial Society/deliveries_model.py
+++ b/Gig Economy - Artificial Society/deliveries_model.py
@@ -4,6 +4,26 @@ from mesa.space import MultiGrid
 from mesa.datacollection import DataCollector
 
 
+def _compute_hist(data, bins=10):
+    """Return a histogram count list for the given data."""
+    if not data:
+        return [0] * bins
+    min_val = min(data)
+    max_val = max(data)
+    if max_val == min_val:
+        hist = [0] * bins
+        hist[0] = len(data)
+        return hist
+    bin_size = (max_val - min_val) / bins
+    hist = [0] * bins
+    for value in data:
+        index = int((value - min_val) / bin_size)
+        if index >= bins:
+            index = bins - 1
+        hist[index] += 1
+    return hist
+
+
 class DeliveryAgent(Agent):
     def __init__(self, unique_id, model):
         super().__init__(unique_id, model)
@@ -42,6 +62,7 @@ class DeliveryAgent(Agent):
             # Tempo de espera até a próxima entrega
             wait_time = self.random.uniform(*self.model.wait_time_range)
             total_hours += wait_time / 60
+            self.model.wait_times.append(wait_time)
             if total_hours >= self.daily_work_limit:
                 break
 
@@ -52,6 +73,7 @@ class DeliveryAgent(Agent):
                 total_hours += delivery_time / 60
                 earnings += delivery_value
                 deliveries += 1
+                self.model.delivery_values.append(delivery_value)
             # Se não aceitar, volta para o loop e espera a próxima
 
         self.hours_worked = total_hours
@@ -109,6 +131,10 @@ class DeliveryModel(Model):
         self.wait_time_range = wait_time_range
         self.acceptance_rate = acceptance_rate
 
+        # Lists to store values for histograms each step
+        self.delivery_values = []
+        self.wait_times = []
+
         for i in range(self.num_agents):
             a = DeliveryAgent(i, self)
             self.schedule.add(a)
@@ -121,10 +147,15 @@ class DeliveryModel(Model):
                 "Satisfeitos": lambda m: sum([1 for a in m.schedule.agents if a.state == "satisfeito"]),
                 "NaoSatisfeitos": lambda m: sum([1 for a in m.schedule.agents if a.state == "não satisfeito"]),
                 "Exaustos": lambda m: sum([1 for a in m.schedule.agents if a.state == "exausto"]),
-                "Pedidos": lambda m: sum(a.deliveries for a in m.schedule.agents)
+                "Pedidos": lambda m: sum(a.deliveries for a in m.schedule.agents),
+                "DeliveryValueHist": lambda m: _compute_hist(m.delivery_values),
+                "WaitTimeHist": lambda m: _compute_hist(m.wait_times),
             }
         )
 
     def step(self):
+        # Reset per-step logs
+        self.delivery_values.clear()
+        self.wait_times.clear()
         self.schedule.step()
         self.datacollector.collect(self)

--- a/Gig Economy - Artificial Society/deliveries_model.py
+++ b/Gig Economy - Artificial Society/deliveries_model.py
@@ -148,8 +148,8 @@ class DeliveryModel(Model):
                 "NaoSatisfeitos": lambda m: sum([1 for a in m.schedule.agents if a.state == "não satisfeito"]),
                 "Exaustos": lambda m: sum([1 for a in m.schedule.agents if a.state == "exausto"]),
                 "Pedidos": lambda m: sum(a.deliveries for a in m.schedule.agents),
-                "DeliveryValueHist": lambda m: _compute_hist(m.delivery_values),
-                "WaitTimeHist": lambda m: _compute_hist(m.wait_times),
+                **{f"ValueBin{i}": (lambda i: lambda m: _compute_hist(m.delivery_values)[i])(i) for i in range(10)},
+                **{f"WaitBin{i}": (lambda i: lambda m: _compute_hist(m.wait_times)[i])(i) for i in range(10)},
             }
         )
 

--- a/Gig Economy - Artificial Society/server.py
+++ b/Gig Economy - Artificial Society/server.py
@@ -1,4 +1,4 @@
-from mesa.visualization.modules import CanvasGrid, ChartModule, HistogramModule
+from mesa.visualization.modules import CanvasGrid, ChartModule
 from mesa.visualization.ModularVisualization import ModularServer
 from deliveries_model import DeliveryModel, DeliveryAgent
 
@@ -26,22 +26,22 @@ chart = ChartModule([
 deliveries_chart = ChartModule(
     [
         {"Label": "Pedidos", "Color": "blue"},
-    ])
-
-value_hist = HistogramModule(
-    list_name="DeliveryValueHist",
-    canvas_height=200,
-    canvas_width=400,
-    bins=10,
-    name="Valores das Entregas",
+    ]
 )
 
-wait_hist = HistogramModule(
-    list_name="WaitTimeHist",
-    canvas_height=200,
-    canvas_width=400,
-    bins=10,
-    name="Tempo de Espera",
+# Display the histogram counts for delivery values
+value_hist = ChartModule(
+    [
+        {"Label": f"ValueBin{i}", "Color": "blue"} for i in range(10)
+    ],
+    data_collector_name="datacollector"
+)
+
+wait_hist = ChartModule(
+    [
+        {"Label": f"WaitBin{i}", "Color": "orange"} for i in range(10)
+    ],
+    data_collector_name="datacollector"
 )
 
 model_params = {

--- a/Gig Economy - Artificial Society/server.py
+++ b/Gig Economy - Artificial Society/server.py
@@ -1,4 +1,4 @@
-from mesa.visualization.modules import CanvasGrid, ChartModule
+from mesa.visualization.modules import CanvasGrid, ChartModule, HistogramModule
 from mesa.visualization.ModularVisualization import ModularServer
 from deliveries_model import DeliveryModel, DeliveryAgent
 
@@ -28,6 +28,22 @@ deliveries_chart = ChartModule(
         {"Label": "Pedidos", "Color": "blue"},
     ])
 
+value_hist = HistogramModule(
+    list_name="DeliveryValueHist",
+    canvas_height=200,
+    canvas_width=400,
+    bins=10,
+    name="Valores das Entregas",
+)
+
+wait_hist = HistogramModule(
+    list_name="WaitTimeHist",
+    canvas_height=200,
+    canvas_width=400,
+    bins=10,
+    name="Tempo de Espera",
+)
+
 model_params = {
     "N": 1000,
     "delivery_value_range": (7.5, 10),
@@ -42,7 +58,7 @@ model_params = {
 
 server = ModularServer(
     DeliveryModel,
-    [grid, chart, deliveries_chart],
+    [grid, chart, deliveries_chart, value_hist, wait_hist],
     "Modelo de Entregadores",
     model_params
 )

--- a/Gig Economy - Artificial Society/server.py
+++ b/Gig Economy - Artificial Society/server.py
@@ -30,10 +30,14 @@ deliveries_chart = ChartModule(
 
 model_params = {
     "N": 1000,
-    "daily_income_target": 100,
-    "daily_work_limit": 12,
     "delivery_value_range": (7.5, 10),
-    "delivery_time_range": (30, 60)
+    "delivery_time_range": (30, 60),
+    "part_time_work_range": (2, 4),
+    "full_time_work_range": (6, 12),
+    "part_time_income_range": (20, 50),
+    "full_time_income_range": (50, 100),
+    "wait_time_range": (15, 30),
+    "acceptance_rate": 0.8,
 }
 
 server = ModularServer(


### PR DESCRIPTION
## Summary
- add part-time and full-time workers in `deliveries_model`
- simulate waiting time and delivery acceptance
- expose new parameters in the server

## Testing
- `python -m py_compile "Gig Economy - Artificial Society"/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c798740a8832eb121fe5c431f28a1