### PR TITLE
Add custom histogram and scatter visualization

### DIFF
--- a/Gig Economy - Artificial Society/server.py
+++ b/Gig Economy - Artificial Society/server.py
@@ -1,6 +1,7 @@
 from mesa.visualization.modules import CanvasGrid, ChartModule
 from mesa.visualization.ModularVisualization import ModularServer
 from deliveries_model import DeliveryModel, DeliveryAgent
+from visualization import HistogramModule, ScatterPlotModule, StackedAreaChartModule
 
 def agent_portrayal(agent):
     portrayal = {
@@ -17,7 +18,7 @@ def agent_portrayal(agent):
 
 grid = CanvasGrid(agent_portrayal, 50, 50, 500, 500)
 
-chart = ChartModule([
+states_chart = StackedAreaChartModule([
     {"Label": "Satisfeitos", "Color": "green"},
     {"Label": "NaoSatisfeitos", "Color": "orange"},
     {"Label": "Exaustos", "Color": "red"}
@@ -27,6 +28,11 @@ deliveries_chart = ChartModule(
     [
         {"Label": "Pedidos", "Color": "blue"},
     ])
+
+hours_hist = HistogramModule(bins=10, calculation=lambda a: a.hours_worked)
+earnings_hist = HistogramModule(bins=10, calculation=lambda a: a.earnings)
+
+phase_space = ScatterPlotModule(lambda a: a.hours_worked, lambda a: a.earnings)
 
 model_params = {
     "N": 1000,
@@ -38,9 +44,16 @@ model_params = {
 
 server = ModularServer(
     DeliveryModel,
-    [grid, chart, deliveries_chart],
+    [
+        grid,
+        states_chart,
+        deliveries_chart,
+        hours_hist,
+        earnings_hist,
+        phase_space,
+    ],
     "Modelo de Entregadores",
-    model_params
+    model_params,
 )
 
 server.port = 8521

--- a/Gig Economy - Artificial Society/visualization/HistogramModule.js
+++ b/Gig Economy - Artificial Society/visualization/HistogramModule.js
@@ -1,0 +1,30 @@
+var HistogramModule = function(bins, canvas_width, canvas_height) {
+    var canvas = document.createElement('canvas');
+    canvas.width = canvas_width;
+    canvas.height = canvas_height;
+    this.canvas = canvas;
+    var ctx = canvas.getContext('2d');
+    var labels = [];
+    for (var i = 0; i < bins; i++) {
+        labels.push(i.toString());
+    }
+    this.chart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: labels,
+            datasets: [{
+                backgroundColor: 'rgba(54, 162, 235, 0.5)',
+                borderColor: 'rgba(54, 162, 235, 1)',
+                data: new Array(bins).fill(0)
+            }]
+        },
+        options: {
+            animation: false,
+            scales: { y: { beginAtZero: true } }
+        }
+    });
+    this.render = function(data) {
+        this.chart.data.datasets[0].data = data;
+        this.chart.update();
+    };
+};

--- a/Gig Economy - Artificial Society/visualization/ScatterPlotModule.js
+++ b/Gig Economy - Artificial Society/visualization/ScatterPlotModule.js
@@ -1,0 +1,22 @@
+var ScatterPlotModule = function(canvas_width, canvas_height) {
+    var canvas = document.createElement('canvas');
+    canvas.width = canvas_width;
+    canvas.height = canvas_height;
+    this.canvas = canvas;
+    var ctx = canvas.getContext('2d');
+    this.chart = new Chart(ctx, {
+        type: 'scatter',
+        data: { datasets: [{ label: '', data: [] }] },
+        options: {
+            animation: false,
+            scales: {
+                x: { type: 'linear', position: 'bottom' },
+                y: { beginAtZero: true }
+            }
+        }
+    });
+    this.render = function(data) {
+        this.chart.data.datasets[0].data = data;
+        this.chart.update();
+    };
+};

--- a/Gig Economy - Artificial Society/visualization/StackedAreaChartModule.js
+++ b/Gig Economy - Artificial Society/visualization/StackedAreaChartModule.js
@@ -1,0 +1,38 @@
+var StackedAreaChartModule = function(series, canvas_width, canvas_height) {
+    var canvas = document.createElement('canvas');
+    canvas.width = canvas_width;
+    canvas.height = canvas_height;
+    this.canvas = canvas;
+    var ctx = canvas.getContext('2d');
+    var datasets = [];
+    for (var i = 0; i < series.length; i++) {
+        datasets.push({
+            label: series[i].Label,
+            borderColor: series[i].Color,
+            backgroundColor: series[i].Color,
+            fill: true,
+            data: []
+        });
+    }
+    this.chart = new Chart(ctx, {
+        type: 'line',
+        data: { labels: [], datasets: datasets },
+        options: {
+            animation: false,
+            scales: {
+                x: { stacked: true },
+                y: { stacked: true, beginAtZero: true }
+            }
+        }
+    });
+    this.step = 0;
+    this.render = function(data) {
+        this.chart.data.labels.push(this.step.toString());
+        this.step += 1;
+        for (var i = 0; i < datasets.length; i++) {
+            var label = series[i].Label;
+            this.chart.data.datasets[i].data.push(data[label]);
+        }
+        this.chart.update();
+    };
+};

--- a/Gig Economy - Artificial Society/visualization/__init__.py
+++ b/Gig Economy - Artificial Society/visualization/__init__.py
@@ -1,0 +1,7 @@
+from .extra_visualizations import HistogramModule, ScatterPlotModule, StackedAreaChartModule
+
+__all__ = [
+    "HistogramModule",
+    "ScatterPlotModule",
+    "StackedAreaChartModule",
+]

--- a/Gig Economy - Artificial Society/visualization/extra_visualizations.py
+++ b/Gig Economy - Artificial Society/visualization/extra_visualizations.py
@@ -1,0 +1,95 @@
+from mesa.visualization.ModularVisualization import VisualizationElement
+
+class HistogramModule(VisualizationElement):
+    package_includes = ["Chart.min.js"]
+    local_includes = ["HistogramModule.js"]
+
+    def __init__(self, bins=10, canvas_height=200, canvas_width=500, calculation=None):
+        """Create a new HistogramModule.
+
+        Args:
+            bins: Number of bins to divide data into.
+            canvas_height: Height of the canvas in pixels.
+            canvas_width: Width of the canvas in pixels.
+            calculation: Function that receives an agent and returns the value
+                to be aggregated. If None, the agent itself will be used.
+        """
+        self.bins = bins
+        self.canvas_height = canvas_height
+        self.canvas_width = canvas_width
+        self.calculation = calculation or (lambda a: a)
+        new_element = f"new HistogramModule({bins}, {canvas_width}, {canvas_height})"
+        super().__init__(new_element)
+
+    def render(self, model):
+        values = [self.calculation(agent) for agent in model.schedule.agents]
+        if not values:
+            return [0 for _ in range(self.bins)]
+        min_val = min(values)
+        max_val = max(values)
+        if min_val == max_val:
+            counts = [0] * self.bins
+            counts[0] = len(values)
+            return counts
+        bin_width = (max_val - min_val) / float(self.bins)
+        counts = [0] * self.bins
+        for v in values:
+            idx = int((v - min_val) / bin_width)
+            if idx >= self.bins:
+                idx = self.bins - 1
+            counts[idx] += 1
+        return counts
+
+
+class ScatterPlotModule(VisualizationElement):
+    package_includes = ["Chart.min.js"]
+    local_includes = ["ScatterPlotModule.js"]
+
+    def __init__(self, x_fn, y_fn, canvas_height=200, canvas_width=500):
+        """Create a new ScatterPlotModule.
+
+        Args:
+            x_fn: Function that extracts the x value from an agent.
+            y_fn: Function that extracts the y value from an agent.
+        """
+        self.x_fn = x_fn
+        self.y_fn = y_fn
+        self.canvas_height = canvas_height
+        self.canvas_width = canvas_width
+        new_element = f"new ScatterPlotModule({canvas_width}, {canvas_height})"
+        super().__init__(new_element)
+
+    def render(self, model):
+        data = []
+        for agent in model.schedule.agents:
+            data.append({"x": self.x_fn(agent), "y": self.y_fn(agent)})
+        return data
+
+
+class StackedAreaChartModule(VisualizationElement):
+    package_includes = ["Chart.min.js"]
+    local_includes = ["StackedAreaChartModule.js"]
+
+    def __init__(self, series, canvas_height=200, canvas_width=500, data_collector_name="datacollector"):
+        """Create a stacked area chart module.
+
+        Args:
+            series: List of dictionaries with "Label" and "Color" keys.
+            canvas_height: Canvas height.
+            canvas_width: Canvas width.
+            data_collector_name: Name of the model's DataCollector.
+        """
+        self.series = series
+        self.canvas_height = canvas_height
+        self.canvas_width = canvas_width
+        self.data_collector_name = data_collector_name
+        new_element = (
+            f"new StackedAreaChartModule({series}, {canvas_width}, {canvas_height})"
+        )
+        super().__init__(new_element)
+
+    def render(self, model):
+        dc = getattr(model, self.data_collector_name)
+        model_vars = dc.get_model_vars_dataframe()
+        latest = model_vars.iloc[-1]
+        return latest.to_dict()


### PR DESCRIPTION
## Summary
- create visualization modules for histogram, scatter, and stacked area charts
- use the new modules in the delivery server to show agent statistics

## Testing
- `python3 -m py_compile deliveries_model.py server.py visualization/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684c81acc128832e9cc8bb39f4a46875