### PR TITLE
Add phase space scatter plot

### DIFF
--- a/Gig Economy - Artificial Society/PhaseSpaceModule.js
+++ b/Gig Economy - Artificial Society/PhaseSpaceModule.js
@@ -1,0 +1,24 @@
+var PhaseSpaceModule = function(width, height, x_label, y_label, dc_name) {
+    this.canvas = document.createElement('canvas');
+    this.canvas.width = width;
+    this.canvas.height = height;
+    this.dc_name = dc_name;
+    var ctx = this.canvas.getContext('2d');
+    this.chart = new Chart(ctx, {
+        type: 'scatter',
+        data: { datasets: [{ label: 'Agentes', data: [] }] },
+        options: {
+            animation: false,
+            scales: {
+                x: { title: { display: true, text: x_label } },
+                y: { title: { display: true, text: y_label } }
+            }
+        }
+    });
+};
+
+PhaseSpaceModule.prototype.render = function(data) {
+    var points = data[this.dc_name]['PhaseSpace'];
+    this.chart.data.datasets[0].data = points;
+    this.chart.update();
+};

--- a/Gig Economy - Artificial Society/deliveries_model.py
+++ b/Gig Economy - Artificial Society/deliveries_model.py
@@ -75,7 +75,11 @@ class DeliveryModel(Model):
                 "Satisfeitos": lambda m: sum([1 for a in m.schedule.agents if a.state == "satisfeito"]),
                 "NaoSatisfeitos": lambda m: sum([1 for a in m.schedule.agents if a.state == "não satisfeito"]),
                 "Exaustos": lambda m: sum([1 for a in m.schedule.agents if a.state == "exausto"]),
-                "Pedidos": lambda m: sum(a.deliveries for a in m.schedule.agents)
+                "Pedidos": lambda m: sum(a.deliveries for a in m.schedule.agents),
+                "PhaseSpace": lambda m: [
+                    {"x": a.hours_worked, "y": a.earnings}
+                    for a in m.schedule.agents
+                ]
             }
         )
 

--- a/Gig Economy - Artificial Society/phase_space.py
+++ b/Gig Economy - Artificial Society/phase_space.py
@@ -22,3 +22,5 @@ class PhaseSpaceModule(VisualizationElement):
             y_label,
             data_collector_name,
         )
+
+        VisualizationElement.__init__(self)

--- a/Gig Economy - Artificial Society/phase_space.py
+++ b/Gig Economy - Artificial Society/phase_space.py
@@ -1,0 +1,24 @@
+from mesa.visualization.ModularVisualization import VisualizationElement
+
+class PhaseSpaceModule(VisualizationElement):
+    """Scatter plot for hours worked vs earnings."""
+
+    package_includes = ["Chart.min.js"]
+    local_includes = ["PhaseSpaceModule.js"]
+
+    def __init__(self, x_label="Horas Trabalhadas", y_label="Ganhos",
+                 canvas_width=500, canvas_height=500,
+                 data_collector_name="datacollector"):
+        self.x_label = x_label
+        self.y_label = y_label
+        self.canvas_width = canvas_width
+        self.canvas_height = canvas_height
+        self.data_collector_name = data_collector_name
+
+        self.js_code = "new PhaseSpaceModule({}, {}, '{}', '{}', '{}')".format(
+            canvas_width,
+            canvas_height,
+            x_label,
+            y_label,
+            data_collector_name,
+        )

--- a/Gig Economy - Artificial Society/server.py
+++ b/Gig Economy - Artificial Society/server.py
@@ -1,6 +1,7 @@
 from mesa.visualization.modules import CanvasGrid, ChartModule
 from mesa.visualization.ModularVisualization import ModularServer
 from deliveries_model import DeliveryModel, DeliveryAgent
+from phase_space import PhaseSpaceModule
 
 def agent_portrayal(agent):
     portrayal = {
@@ -28,6 +29,8 @@ deliveries_chart = ChartModule(
         {"Label": "Pedidos", "Color": "blue"},
     ])
 
+phase_chart = PhaseSpaceModule()
+
 model_params = {
     "N": 1000,
     "daily_income_target": 100,
@@ -38,7 +41,7 @@ model_params = {
 
 server = ModularServer(
     DeliveryModel,
-    [grid, chart, deliveries_chart],
+    [grid, chart, deliveries_chart, phase_chart],
     "Modelo de Entregadores",
     model_params
 )


### PR DESCRIPTION
## Summary
- collect each agent's worked hours and earnings in `PhaseSpace` reporter
- add new `PhaseSpaceModule` visualization element with JS component
- display phase space scatter plot on Mesa server

## Testing
- `python -m py_compile deliveries_model.py server.py phase_space.py`

------
https://chatgpt.com/codex/tasks/task_e_684c8957e894832e94f65ad12e50172b